### PR TITLE
Update maven-shade-plugin to version 2.3

### DIFF
--- a/japi-checker-cli/pom.xml
+++ b/japi-checker-cli/pom.xml
@@ -65,7 +65,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.0</version>
+				<version>2.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
The project fails to build with maven >= 3.1. Version of maven-shade-plugin seems to be too old for relatively new maven. I am getting following error message:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:2.0:shade (default) on project japi-checker-cli: Execution default of goal org.apache.maven.plugins:maven-shade-plugin:2.0:shade failed: A required class was missing while executing org.apache.maven.plugins:maven-shade-plugin:2.0:shade: org/sonatype/aether/graph/Dependency

Update of maven-shade-plugin dependency to latest version solves the problem for me.
