### PR TITLE
Update to latest asm and fix maven build

### DIFF
--- a/japi-checker-cli/pom.xml
+++ b/japi-checker-cli/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>japi-checker-pom</artifactId>
 		<groupId>com.googlecode.japi-checker</groupId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>japi-checker-cli</artifactId>

--- a/japi-checker-maven-plugin/pom.xml
+++ b/japi-checker-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>japi-checker-pom</artifactId>
 		<groupId>com.googlecode.japi-checker</groupId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/japi-checker/pom.xml
+++ b/japi-checker/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<artifactId>japi-checker-pom</artifactId>
 		<groupId>com.googlecode.japi-checker</groupId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>annotations</artifactId>
-			<version>2.0.0</version>
+			<version>3.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/japi-checker/pom.xml
+++ b/japi-checker/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
-			<version>4.0</version>
+			<version>6.0_BETA</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/japi-checker/src/main/java/com/googlecode/japi/checker/AnnotationDumper.java
+++ b/japi-checker/src/main/java/com/googlecode/japi/checker/AnnotationDumper.java
@@ -15,7 +15,7 @@ public class AnnotationDumper extends AnnotationVisitor {
 	private final MethodData method;
 
 	public AnnotationDumper(MethodData method) {
-		super(Opcodes.ASM4);
+		super(Opcodes.ASM6);
 		this.method = method;
 	}
 

--- a/japi-checker/src/main/java/com/googlecode/japi/checker/ClassDumper.java
+++ b/japi-checker/src/main/java/com/googlecode/japi/checker/ClassDumper.java
@@ -59,7 +59,7 @@ class ClassDumper<C extends ClassData> extends ClassVisitor {
 					   Class<? extends FieldData> fieldClass,
 					   Class<? extends MethodData> methodClass,
 					   Class<? extends TypeParameterData> typeParameterClass) {
-		super(Opcodes.ASM4);
+		super(Opcodes.ASM6);
 		this.loader = loader;
 		try {
 			this.classConstructor = classClass.getConstructor(ClassDataLoader.class, ClassData.class, int.class, String.class, String.class, String[].class, int.class);

--- a/japi-checker/src/main/java/com/googlecode/japi/checker/MethodDumper.java
+++ b/japi-checker/src/main/java/com/googlecode/japi/checker/MethodDumper.java
@@ -30,7 +30,7 @@ public class MethodDumper extends MethodVisitor {
 	private Logger logger = Logger.getLogger(MethodDumper.class.getName());
 
 	public MethodDumper(MethodData method) {
-		super(Opcodes.ASM4);
+		super(Opcodes.ASM6);
 		this.method = method;
 	}
 

--- a/japi-checker/src/main/java/com/googlecode/japi/checker/TypeParameterDumper.java
+++ b/japi-checker/src/main/java/com/googlecode/japi/checker/TypeParameterDumper.java
@@ -20,7 +20,7 @@ public class TypeParameterDumper extends SignatureVisitor {
 	private Constructor<? extends TypeParameterData> typeParameterConstructor;
 
 	public TypeParameterDumper(Parametrized item, Constructor<? extends TypeParameterData> typeParameterConstructor) {
-		super(Opcodes.ASM4);
+		super(Opcodes.ASM6);
 		this.item = item;
 		this.typeParameterConstructor = typeParameterConstructor;
 	}

--- a/new-test-jar/pom.xml
+++ b/new-test-jar/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<artifactId>japi-checker-pom</artifactId>
 		<groupId>com.googlecode.japi-checker</groupId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>new-test-jar</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
 	<groupId>com.googlecode.japi-checker</groupId>
 	<artifactId>japi-checker-pom</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>JAPI Checker :: Parent POM</name>
@@ -106,7 +106,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>2.5.2</version>
+				<version>3.0.5</version>
 				<executions>
 					<execution>
 						<id>findbugs-verify</id>

--- a/reference-test-jar/pom.xml
+++ b/reference-test-jar/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<artifactId>japi-checker-pom</artifactId>
 		<groupId>com.googlecode.japi-checker</groupId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>reference-test-jar</artifactId>


### PR DESCRIPTION
Hi there,

We ran into some issues with use of the japi checker at work due to java 8+. I have updated it to the latest asm version available, and also fixed the maven build (mvn install works again).

Could you please merge this pull request and release to maven?

Thank you.

